### PR TITLE
Unify orchestrator into event-driven architecture and add usability features (P0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # ASDV (Agile Synthetic Dev Vibe)
-A .NET 8 console-based coding agent that operates on local repositories, inspired by Claude Code.  
- Supports OpenAI, Anthropic, and OpenAI-compatible endpoints with a provider-agnostic architecture.
+A .NET 8 coding agent that operates on local repositories with a clean, event-driven architecture.  
+Supports OpenAI, Anthropic, and OpenAI-compatible endpoints (llama.cpp, vLLM, Ollama, OpenRouter) with full provider freedom.
 
 ## Features
 
-- **Provider-agnostic**: Switch between OpenAI, Anthropic, and OpenAI-compatible endpoints
-- **Streaming**: Real-time streaming of model responses via SSE
-- **Tool system**: Extensible tools for file operations, search, git, and command execution
+- **Provider freedom**: Switch between OpenAI, Anthropic, local LLMs, and OpenRouter — no vendor lock-in
+- **Event-driven core**: Unified `IAsyncEnumerable<AgentEvent>` orchestrator shared by CLI and HTTP server
+- **Tool system**: File read/edit, glob search, regex grep, git operations, and shell commands
+- **Interactive commands**: `/status`, `/help`, `/diff` for session inspection
+- **Flexible resume**: Resume sessions with `--resume-mode=full|summary|last-N` for any context window size
 - **Policy-based approval**: Dangerous operations require user approval
 - **Session logging**: JSONL logs for reproducibility and debugging
 - **Path safety**: Prevents path traversal and symlink escape attacks
+- **Project-level prompts**: Drop a `.asdv/prompt.md` to customize the system prompt per project
 
 ## Quick Start
 
@@ -57,6 +60,12 @@ dotnet run --project src/Agent.Cli -- -r /path/to/repo -p anthropic "Review the 
 
 # Use OpenAI-compatible endpoint via config
 dotnet run --project src/Agent.Cli -- -r /path/to/repo -p openai-compatible
+
+# Resume a session with summary mode (ideal for small context windows)
+dotnet run --project src/Agent.Cli -- --session-id abc123 --resume-mode summary
+
+# Resume with only the last 3 turns
+dotnet run --project src/Agent.Cli -- --session-id abc123 --resume-mode last-3
 ```
 
 ### CLI Options
@@ -73,17 +82,20 @@ dotnet run --project src/Agent.Cli -- -r /path/to/repo -p openai-compatible
 | `--once` | | Run a single prompt and exit | `false` |
 | `--max-iterations` | | Maximum agent iterations | `20` |
 | `--debug` | `-d` | Enable debug output (stack traces) | `false` |
+| `--resume-mode` | | Resume mode: `full`, `summary`, `last-N` | `full` |
 
 ## Architecture
 
 ```
 Agent.sln
 src/
-  Agent.Cli/           # Entry point, CLI parsing
-  Agent.Core/          # Orchestrator, events, policies
+  Agent.Cli/           # Entry point, CLI parsing, commands, rendering
+    Commands/          # /status, /help, /diff command implementations
+    Rendering/         # ConsoleEventRenderer, TextStreamFormatter
+  Agent.Core/          # Orchestrator (event-driven), events, policies
   Agent.Llm.Anthropic/ # Claude Messages API provider
   Agent.Llm.OpenAI/    # OpenAI Chat Completions API provider
-  Agent.Tools/         # Tool implementations
+  Agent.Tools/         # Tool implementations (read, edit, search, git, shell)
   Agent.Workspace/     # File system safety
   Agent.Logging/       # JSONL session logging
   Agent.Server/        # HTTP API server for agent sessions
@@ -95,17 +107,36 @@ scripts/
   server-client.mjs    # Node.js client for Agent.Server
 ```
 
+### Event-Driven Architecture
+
+The core orchestrator (`AgentOrchestrator.RunStreamAsync`) returns an `IAsyncEnumerable<AgentEvent>` stream. Both CLI and Server consume this same stream through thin adapters:
+
+- **CLI**: `ConsoleEventRenderer` renders events to the terminal with colors and formatting
+- **Server**: `SessionRunner` maps events to `ServerEvent` types and writes to SSE channels
+
+This eliminates code duplication and ensures both surfaces behave identically.
+
 ### Available Tools
 
 | Tool | Description | Requires Approval |
 |------|-------------|-------------------|
 | `ReadFile` | Read file contents with optional line range | No |
-| `ListFiles` | List files matching glob patterns | No |
-| `SearchText` | Search for text patterns (regex) | No |
+| `ListFiles` | List files matching glob patterns (supports `path`, `sortBy=modified`) | No |
+| `SearchText` | Search for text patterns with regex (supports `contextLines`, `caseSensitive`) | No |
 | `GitStatus` | Get repository status | No |
 | `GitDiff` | View staged/unstaged changes | No |
+| `FileEdit` | Precise string replacement in files | Yes |
 | `ApplyPatch` | Apply unified diff or Begin Patch format patches | Yes |
 | `RunCommand` | Execute shell commands | Yes |
+
+### REPL Commands
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/status` | Show current session status (provider, model, session ID) |
+| `/diff` | Show git diff summary |
+| `/exit`, `/quit`, `/q` | Exit the REPL |
 
 ## Configuration
 
@@ -121,6 +152,15 @@ scripts/
 
 - **Anthropic**: `claude-sonnet-4-20250514`
 - **OpenAI**: `gpt-5-mini`
+
+### Project-Level Prompt (`.asdv/prompt.md`)
+
+Create a `.asdv/prompt.md` file in your repository root to add project-specific instructions to the system prompt. This is useful for:
+- Defining project conventions and coding standards
+- Adding context about the project architecture
+- Customizing behavior for specific LLM models
+
+The content is appended to the base system prompt automatically.
 
 ### YAML Config (asdv.yaml)
 
@@ -147,7 +187,16 @@ Session logs are saved in JSONL format to `.agent/session_<sessionId>.jsonl` by 
 - **`--session-id <id>`**: Create or resume a session with the specified ID. Sessions are stored as `.agent/session_<id>.jsonl`
 - **`--session <path>`**: Specify a custom path for the session log file (mutually exclusive with `--session-id`)
 - **Session index**: All sessions are tracked in `.agent/sessions.jsonl` for discovery and debugging
-- **Resumption**: When you resume a session with `--session-id`, the agent loads all previous messages and continues the conversation
+
+### Resume Modes
+
+When resuming a session, you can choose how much history to load with `--resume-mode`:
+
+| Mode | Description | Best for |
+|------|-------------|----------|
+| `full` (default) | Load all previous messages | Large context windows (128K+) |
+| `summary` | Generate a structured summary of the session | Small context windows (4K–8K), local LLMs |
+| `last-N` (e.g., `last-3`) | Load only the last N conversation turns | Medium context windows, focused continuation |
 
 ### REPL vs. Once Mode
 

--- a/src/Agent.Cli/Commands/CommandRegistry.cs
+++ b/src/Agent.Cli/Commands/CommandRegistry.cs
@@ -1,0 +1,33 @@
+namespace Agent.Cli.Commands;
+
+public class CommandRegistry
+{
+    private readonly Dictionary<string, ICommand> _commands = new(StringComparer.OrdinalIgnoreCase);
+
+    public void Register(ICommand command)
+    {
+        _commands[command.Name] = command;
+    }
+
+    public bool TryExecute(string input, CommandContext context, out Task task)
+    {
+        var parts = input.TrimStart('/').Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            task = Task.CompletedTask;
+            return false;
+        }
+
+        if (_commands.TryGetValue(parts[0], out var command))
+        {
+            var args = parts.Length > 1 ? parts[1..] : Array.Empty<string>();
+            task = command.ExecuteAsync(args, context);
+            return true;
+        }
+
+        task = Task.CompletedTask;
+        return false;
+    }
+
+    public IEnumerable<ICommand> GetAll() => _commands.Values;
+}

--- a/src/Agent.Cli/Commands/DiffCommand.cs
+++ b/src/Agent.Cli/Commands/DiffCommand.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+
+namespace Agent.Cli.Commands;
+
+public class DiffCommand : ICommand
+{
+    public string Name => "diff";
+    public string Description => "Show git diff summary";
+
+    public async Task ExecuteAsync(string[] args, CommandContext context)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = context.RepoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        psi.ArgumentList.Add("diff");
+        psi.ArgumentList.Add("--stat");
+
+        try
+        {
+            using var process = Process.Start(psi)!;
+            var output = await process.StandardOutput.ReadToEndAsync();
+            await process.WaitForExitAsync();
+
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine("No unstaged changes.");
+                Console.ResetColor();
+            }
+            else
+            {
+                Console.WriteLine(output.TrimEnd());
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"Failed to run git diff: {ex.Message}");
+            Console.ResetColor();
+        }
+    }
+}

--- a/src/Agent.Cli/Commands/HelpCommand.cs
+++ b/src/Agent.Cli/Commands/HelpCommand.cs
@@ -1,0 +1,25 @@
+namespace Agent.Cli.Commands;
+
+public class HelpCommand : ICommand
+{
+    private readonly CommandRegistry _registry;
+
+    public HelpCommand(CommandRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    public string Name => "help";
+    public string Description => "Show available commands";
+
+    public Task ExecuteAsync(string[] args, CommandContext context)
+    {
+        Console.WriteLine("Available commands:");
+        foreach (var cmd in _registry.GetAll())
+        {
+            Console.WriteLine($"  /{cmd.Name,-12} {cmd.Description}");
+        }
+        Console.WriteLine($"  /{"exit",-12} Exit the REPL");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Agent.Cli/Commands/ICommand.cs
+++ b/src/Agent.Cli/Commands/ICommand.cs
@@ -1,0 +1,18 @@
+namespace Agent.Cli.Commands;
+
+public interface ICommand
+{
+    string Name { get; }
+    string Description { get; }
+    Task ExecuteAsync(string[] args, CommandContext context);
+}
+
+public record CommandContext
+{
+    public required string ProviderName { get; init; }
+    public required string ModelName { get; init; }
+    public required string SessionId { get; init; }
+    public required string SessionPath { get; init; }
+    public required string RepoRoot { get; init; }
+    public required bool AutoApprove { get; init; }
+}

--- a/src/Agent.Cli/Commands/StatusCommand.cs
+++ b/src/Agent.Cli/Commands/StatusCommand.cs
@@ -1,0 +1,21 @@
+namespace Agent.Cli.Commands;
+
+public class StatusCommand : ICommand
+{
+    public string Name => "status";
+    public string Description => "Show current session status";
+
+    public Task ExecuteAsync(string[] args, CommandContext context)
+    {
+        Console.ForegroundColor = ConsoleColor.Cyan;
+        Console.WriteLine("Session Status");
+        Console.ResetColor();
+        Console.WriteLine($"  Provider:     {context.ProviderName}");
+        Console.WriteLine($"  Model:        {context.ModelName}");
+        Console.WriteLine($"  Session ID:   {context.SessionId}");
+        Console.WriteLine($"  Session path: {context.SessionPath}");
+        Console.WriteLine($"  Repository:   {context.RepoRoot}");
+        Console.WriteLine($"  Auto-approve: {context.AutoApprove}");
+        return Task.CompletedTask;
+    }
+}

--- a/src/Agent.Cli/Program.cs
+++ b/src/Agent.Cli/Program.cs
@@ -1,6 +1,8 @@
 using System.CommandLine;
 using System.Text.Json;
 using Agent.Cli;
+using Agent.Cli.Commands;
+using Agent.Cli.Rendering;
 using Agent.Core.Config;
 using Agent.Core.Approval;
 using Agent.Core.Logging;
@@ -63,6 +65,11 @@ var onceOption = new Option<bool>(
     getDefaultValue: () => false,
     description: "Run a single prompt and exit (non-interactive)");
 
+var resumeModeOption = new Option<string>(
+    aliases: ["--resume-mode"],
+    getDefaultValue: () => "full",
+    description: "Resume mode: full|summary|last-N (e.g., last-5)");
+
 var promptArgument = new Argument<string?>(
     name: "prompt",
     description: "Task prompt for the agent")
@@ -70,7 +77,7 @@ var promptArgument = new Argument<string?>(
     Arity = ArgumentArity.ZeroOrOne
 };
 
-var rootCommand = new RootCommand("ASDV - Claude Code style")
+var rootCommand = new RootCommand("ASDV - Your AI Coding Assistant")
 {
     repoOption,
     providerOption,
@@ -82,6 +89,7 @@ var rootCommand = new RootCommand("ASDV - Claude Code style")
     debugOption,
     onceOption,
     configOption,
+    resumeModeOption,
     promptArgument
 };
 
@@ -97,6 +105,7 @@ rootCommand.SetHandler(async (context) =>
     var debug = context.ParseResult.GetValueForOption(debugOption);
     var once = context.ParseResult.GetValueForOption(onceOption);
     var config = context.ParseResult.GetValueForOption(configOption);
+    var resumeMode = context.ParseResult.GetValueForOption(resumeModeOption)!;
     var prompt = context.ParseResult.GetValueForArgument(promptArgument);
 
     var ct = context.GetCancellationToken();
@@ -112,6 +121,7 @@ rootCommand.SetHandler(async (context) =>
         debug,
         once,
         config,
+        resumeMode,
         prompt,
         ct);
 });
@@ -129,6 +139,7 @@ static async Task RunAgentAsync(
     bool debug,
     bool once,
     string? config,
+    string resumeMode,
     string? prompt,
     CancellationToken ct)
 {
@@ -220,7 +231,8 @@ static async Task RunAgentAsync(
     var messages = new List<Agent.Core.Messages.ChatMessage>();
     if (resumed)
     {
-        messages = SessionLogReader.LoadMessages(sessionPath, warning =>
+        var (parsedResumeMode, lastN) = ParseResumeMode(resumeMode);
+        messages = SessionLogReader.LoadMessages(sessionPath, parsedResumeMode, lastN, warning =>
         {
             if (debug)
             {
@@ -229,6 +241,13 @@ static async Task RunAgentAsync(
                 Console.ResetColor();
             }
         });
+
+        if (parsedResumeMode != ResumeMode.Full)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"  Resume mode: {resumeMode} ({messages.Count} messages loaded)");
+            Console.ResetColor();
+        }
     }
 
     ISessionLogger logger;
@@ -253,7 +272,7 @@ static async Task RunAgentAsync(
         Workspace = workspace,
         MaxIterations = maxIterations,
         MaxTokens = 4096,
-        SystemPrompt = GetSystemPrompt()
+        SystemPrompt = GetSystemPrompt(toolRegistry, repoRoot)
     };
 
     // Print header
@@ -311,11 +330,29 @@ static async Task RunAgentAsync(
             mode = once ? "once" : "repl"
         });
 
+        var renderer = new ConsoleEventRenderer();
+
+        // Set up command system
+        var commandRegistry = new CommandRegistry();
+        var commandContext = new CommandContext
+        {
+            ProviderName = resolvedProvider,
+            ModelName = resolvedModel,
+            SessionId = sessionId,
+            SessionPath = sessionPath,
+            RepoRoot = repoRoot,
+            AutoApprove = autoApprove
+        };
+        commandRegistry.Register(new StatusCommand());
+        commandRegistry.Register(new DiffCommand());
+        // HelpCommand needs registry reference — register last
+        commandRegistry.Register(new HelpCommand(commandRegistry));
+
         if (once)
         {
             if (!string.IsNullOrWhiteSpace(prompt))
             {
-                await orchestrator.RunAsync(prompt, messages, ct);
+                await RunStreamToConsoleAsync(orchestrator, renderer, prompt, messages, ct);
             }
 
             return;
@@ -327,7 +364,7 @@ static async Task RunAgentAsync(
 
         if (!string.IsNullOrWhiteSpace(prompt))
         {
-            await orchestrator.RunAsync(prompt, messages, ct);
+            await RunStreamToConsoleAsync(orchestrator, renderer, prompt, messages, ct);
         }
 
         while (true)
@@ -349,18 +386,27 @@ static async Task RunAgentAsync(
                 break;
             }
 
-            if (string.Equals(input, "/help", StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine("Commands: /exit, /quit, /help");
-                continue;
-            }
-
             if (string.IsNullOrWhiteSpace(input))
             {
                 continue;
             }
 
-            await orchestrator.RunAsync(input, messages, ct);
+            if (input.StartsWith("/"))
+            {
+                if (commandRegistry.TryExecute(input, commandContext, out var cmdTask))
+                {
+                    await cmdTask;
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+                    Console.WriteLine($"Unknown command: {input}. Type /help for available commands.");
+                    Console.ResetColor();
+                }
+                continue;
+            }
+
+            await RunStreamToConsoleAsync(orchestrator, renderer, input, messages, ct);
         }
     }
     catch (OperationCanceledException)
@@ -527,44 +573,42 @@ static ToolRegistry CreateToolRegistry()
     registry.Register(new GitDiffTool());
 
     // Write/execute tools
+    registry.Register(new FileEditTool());
     registry.Register(new ApplyPatchTool());
     registry.Register(new RunCommandTool());
 
     return registry;
 }
 
-static string GetSystemPrompt()
+static string GetSystemPrompt(ToolRegistry toolRegistry, string repoRoot)
 {
-    return """
+    var toolDescriptions = toolRegistry.GetToolDescriptionsMarkdown();
+
+    // Load optional project-level prompt customization
+    var projectPromptPath = Path.Combine(repoRoot, ".asdv", "prompt.md");
+    var projectPrompt = File.Exists(projectPromptPath)
+        ? Environment.NewLine + File.ReadAllText(projectPromptPath)
+        : "";
+
+    return $"""
         You are a coding assistant that helps developers with tasks in their local repository.
 
         ## Available Tools
 
-        ### Reading & Exploration
-        - **ReadFile**: Read file contents (supports line ranges)
-        - **ListFiles**: List files matching glob patterns (e.g., **/*.cs)
-        - **SearchText**: Search for text patterns using regex
-
-        ### Git Operations
-        - **GitStatus**: Get current repository status
-        - **GitDiff**: View changes (staged or unstaged)
-
-        ### Modifications
-        - **ApplyPatch**: Apply unified diff patches to modify files
-        - **RunCommand**: Execute shell commands (requires approval)
-
+        {toolDescriptions}
         ## Guidelines
 
         1. **Understand First**: Always read relevant files before making changes
         2. **Search Effectively**: Use SearchText to locate code patterns
-        3. **Precise Changes**: Generate minimal, focused unified diff patches
+        3. **Precise Edits**: Use FileEdit for targeted string replacements, or ApplyPatch for larger changes
         4. **Verify Results**: Check git status/diff after modifications
         5. **Test Changes**: Run tests when appropriate
         6. **Explain Actions**: Briefly describe what you're doing and why
 
-        ## Patch Format
+        ## Edit Strategies
 
-        When modifying files, prefer unified diff format:
+        For small, targeted changes, prefer FileEdit (exact string replacement).
+        For larger or multi-site changes, use ApplyPatch with unified diff format:
         ```
         --- a/path/to/file.cs
         +++ b/path/to/file.cs
@@ -575,16 +619,37 @@ static string GetSystemPrompt()
          context line
         ```
 
-        The ApplyPatch tool also accepts the "Begin Patch" format:
-        ```
-        *** Begin Patch
-        *** Add File: path/to/file.cs
-        +new line
-        *** End Patch
-        ```
-
-        Keep patches minimal and focused on the specific change needed.
+        Keep changes minimal and focused on the specific task.
+        {projectPrompt}
         """;
+}
+
+static async Task RunStreamToConsoleAsync(
+    AgentOrchestrator orchestrator,
+    ConsoleEventRenderer renderer,
+    string prompt,
+    List<Agent.Core.Messages.ChatMessage> messages,
+    CancellationToken ct)
+{
+    await foreach (var evt in orchestrator.RunStreamAsync(prompt, messages, ct))
+    {
+        renderer.Render(evt);
+    }
+}
+
+static (ResumeMode mode, int lastN) ParseResumeMode(string input)
+{
+    if (string.Equals(input, "full", StringComparison.OrdinalIgnoreCase))
+        return (ResumeMode.Full, 0);
+
+    if (string.Equals(input, "summary", StringComparison.OrdinalIgnoreCase))
+        return (ResumeMode.Summary, 0);
+
+    if (input.StartsWith("last-", StringComparison.OrdinalIgnoreCase)
+        && int.TryParse(input[5..], out var n) && n > 0)
+        return (ResumeMode.LastN, n);
+
+    return (ResumeMode.Full, 0);
 }
 
 static string GenerateSessionId()

--- a/src/Agent.Cli/Rendering/ConsoleEventRenderer.cs
+++ b/src/Agent.Cli/Rendering/ConsoleEventRenderer.cs
@@ -1,0 +1,101 @@
+using Agent.Core.Events;
+using Agent.Core.Tools;
+
+namespace Agent.Cli.Rendering;
+
+public sealed class ConsoleEventRenderer
+{
+    private readonly TextStreamFormatter _formatter = new();
+
+    public void Render(AgentEvent evt)
+    {
+        switch (evt)
+        {
+            case TextDelta delta:
+                Console.Write(_formatter.Format(delta.Text));
+                break;
+
+            case ToolCallStarted started:
+                Console.Write(_formatter.Flush());
+                Console.WriteLine();
+                Console.ForegroundColor = ConsoleColor.Cyan;
+                Console.Write($"[tool] {started.ToolName}");
+                Console.ResetColor();
+                break;
+
+            case ToolCallReady ready:
+                Console.WriteLine($" args={Truncate(ready.ArgsJson, 100)}");
+                break;
+
+            case TraceEvent trace when trace.Kind == "error":
+                Console.Write(_formatter.Flush());
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.WriteLine($"[Provider error] {trace.Data}");
+                Console.ResetColor();
+                break;
+
+            case ResponseCompleted:
+                Console.Write(_formatter.Flush());
+                Console.WriteLine();
+                break;
+
+            case ToolExecutionCompleted completed:
+                PrintToolResult(completed.ToolName, completed.Result);
+                break;
+
+            case AgentCompleted:
+                Console.ForegroundColor = ConsoleColor.Green;
+                Console.WriteLine("[Agent completed]");
+                Console.ResetColor();
+                break;
+
+            case AgentError error:
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine($"[{error.Message}]");
+                Console.ResetColor();
+                break;
+
+            case MaxIterationsReached:
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.WriteLine("[Max iterations reached]");
+                Console.ResetColor();
+                break;
+        }
+    }
+
+    private static void PrintToolResult(string toolName, ToolResult result)
+    {
+        if (result.Ok)
+        {
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine($"  [{toolName}] OK");
+        }
+        else
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine($"  [{toolName}] FAILED: {result.Diagnostics?.FirstOrDefault()?.Message}");
+        }
+        Console.ResetColor();
+
+        if (!string.IsNullOrEmpty(result.Stdout))
+        {
+            var preview = TruncateMultiline(result.Stdout, 200);
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"  stdout: {preview}");
+            Console.ResetColor();
+        }
+    }
+
+    private static string Truncate(string text, int maxLength)
+    {
+        if (text.Length <= maxLength) return text;
+        return text[..maxLength] + "...";
+    }
+
+    private static string TruncateMultiline(string str, int maxLength)
+    {
+        var singleLine = str.Replace("\r", "").Replace("\n", " ");
+        if (singleLine.Length <= maxLength) return singleLine;
+        return singleLine[..maxLength] + "...";
+    }
+}

--- a/src/Agent.Cli/Rendering/TextStreamFormatter.cs
+++ b/src/Agent.Cli/Rendering/TextStreamFormatter.cs
@@ -1,0 +1,98 @@
+using System.Text;
+
+namespace Agent.Cli.Rendering;
+
+public sealed class TextStreamFormatter
+{
+    private bool _inCodeBlock;
+    private int _backtickRun;
+    private bool _pendingBackslash;
+
+    public string Format(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return string.Empty;
+        }
+
+        var output = new StringBuilder(text.Length);
+
+        foreach (var ch in text)
+        {
+            if (_pendingBackslash)
+            {
+                if (ch == 'n' && !_inCodeBlock)
+                {
+                    output.AppendLine();
+                }
+                else
+                {
+                    output.Append('\\');
+                    ProcessChar(ch, output);
+                }
+
+                _pendingBackslash = false;
+                continue;
+            }
+
+            if (ch == '\\')
+            {
+                _pendingBackslash = true;
+                continue;
+            }
+
+            ProcessChar(ch, output);
+        }
+
+        return output.ToString();
+    }
+
+    public string Flush()
+    {
+        var output = new StringBuilder();
+
+        if (_pendingBackslash)
+        {
+            output.Append('\\');
+            _pendingBackslash = false;
+        }
+
+        FlushBackticks(output);
+        return output.ToString();
+    }
+
+    private void ProcessChar(char ch, StringBuilder output)
+    {
+        if (ch == '`')
+        {
+            _backtickRun++;
+            return;
+        }
+
+        FlushBackticks(output);
+        output.Append(ch);
+    }
+
+    private void FlushBackticks(StringBuilder output)
+    {
+        if (_backtickRun == 0)
+        {
+            return;
+        }
+
+        var remaining = _backtickRun;
+        while (remaining >= 3)
+        {
+            _inCodeBlock = !_inCodeBlock;
+            output.Append("```");
+            remaining -= 3;
+        }
+
+        if (remaining > 0)
+        {
+            output.Append('`', remaining);
+        }
+
+        _backtickRun = 0;
+    }
+}

--- a/src/Agent.Cli/SessionLogReader.cs
+++ b/src/Agent.Cli/SessionLogReader.cs
@@ -4,12 +4,33 @@ using Agent.Core.Tools;
 
 namespace Agent.Cli;
 
+public enum ResumeMode
+{
+    Full,
+    Summary,
+    LastN
+}
+
 internal static class SessionLogReader
 {
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
         PropertyNameCaseInsensitive = true
     };
+
+    public static List<ChatMessage> LoadMessages(
+        string sessionPath, ResumeMode mode, int lastN, Action<string>? warn = null)
+    {
+        var allMessages = LoadMessages(sessionPath, warn);
+
+        return mode switch
+        {
+            ResumeMode.Full => allMessages,
+            ResumeMode.LastN => TakeLastTurns(allMessages, lastN),
+            ResumeMode.Summary => GenerateSummaryMessages(allMessages),
+            _ => allMessages
+        };
+    }
 
     public static List<ChatMessage> LoadMessages(string sessionPath, Action<string>? warn = null)
     {
@@ -136,5 +157,70 @@ internal static class SessionLogReader
         }
 
         return new ToolResultMessage(callId, toolName, result);
+    }
+
+    private static List<ChatMessage> TakeLastTurns(List<ChatMessage> messages, int turnCount)
+    {
+        if (turnCount <= 0 || messages.Count == 0)
+            return new List<ChatMessage>();
+
+        // A "turn" starts with a UserMessage. Walk backwards to find the start of the Nth-last turn.
+        var turnStarts = new List<int>();
+        for (int i = 0; i < messages.Count; i++)
+        {
+            if (messages[i] is UserMessage)
+                turnStarts.Add(i);
+        }
+
+        if (turnStarts.Count == 0)
+            return new List<ChatMessage>();
+
+        var startIndex = turnStarts[Math.Max(0, turnStarts.Count - turnCount)];
+        return messages.GetRange(startIndex, messages.Count - startIndex);
+    }
+
+    private static List<ChatMessage> GenerateSummaryMessages(List<ChatMessage> messages)
+    {
+        if (messages.Count == 0)
+            return new List<ChatMessage>();
+
+        // Extract metadata from the conversation
+        var userPrompts = new List<string>();
+        var toolNames = new HashSet<string>();
+        int assistantCount = 0;
+
+        foreach (var msg in messages)
+        {
+            switch (msg)
+            {
+                case UserMessage user:
+                    userPrompts.Add(user.Content.Length > 80
+                        ? user.Content[..80] + "..."
+                        : user.Content);
+                    break;
+                case AssistantMessage:
+                    assistantCount++;
+                    break;
+                case ToolResultMessage tool:
+                    toolNames.Add(tool.ToolName);
+                    break;
+            }
+        }
+
+        var parts = new List<string>
+        {
+            $"Previous session: {userPrompts.Count} user messages, {assistantCount} assistant responses."
+        };
+
+        if (toolNames.Count > 0)
+            parts.Add($"Tools used: {string.Join(", ", toolNames)}.");
+
+        if (userPrompts.Count > 0)
+            parts.Add($"Last user prompt: \"{userPrompts[^1]}\"");
+
+        var summary = string.Join(" ", parts)
+            + "\n\nPlease continue from where we left off. Ask if you need context about prior work.";
+
+        return new List<ChatMessage> { new UserMessage(summary) };
     }
 }

--- a/src/Agent.Cli/SessionLogReader.cs
+++ b/src/Agent.Cli/SessionLogReader.cs
@@ -11,7 +11,7 @@ public enum ResumeMode
     LastN
 }
 
-internal static class SessionLogReader
+public static class SessionLogReader
 {
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {

--- a/src/Agent.Core/Approval/AutoApprovalService.cs
+++ b/src/Agent.Core/Approval/AutoApprovalService.cs
@@ -1,0 +1,11 @@
+namespace Agent.Core.Approval;
+
+public sealed class AutoApprovalService : IApprovalService
+{
+    public Task<bool> RequestApprovalAsync(
+        string toolName,
+        string argsJson,
+        string? callId = null,
+        CancellationToken ct = default)
+        => Task.FromResult(true);
+}

--- a/src/Agent.Core/Events/AgentEvent.cs
+++ b/src/Agent.Core/Events/AgentEvent.cs
@@ -26,3 +26,23 @@ public sealed record ResponseCompleted(
 public sealed record TraceEvent(string Kind, string Data) : AgentEvent;
 
 public sealed record UsageInfo(int InputTokens, int OutputTokens);
+
+// Orchestrator-level events (yielded by RunStreamAsync)
+
+public sealed record IterationStarted(int Iteration, int MaxIterations) : AgentEvent;
+
+public sealed record ToolExecutionStarted(string CallId, string ToolName, string ArgsJson) : AgentEvent;
+
+public sealed record ToolExecutionCompleted(string CallId, string ToolName, ToolResult Result) : AgentEvent;
+
+public sealed record ApprovalRequested(string CallId, string ToolName, string ArgsJson) : AgentEvent;
+
+public sealed record ApprovalResult(string CallId, bool Approved) : AgentEvent;
+
+public sealed record AssistantMessageCompleted(string? Text, int ToolCallCount) : AgentEvent;
+
+public sealed record AgentCompleted(string Reason) : AgentEvent;
+
+public sealed record AgentError(string Message) : AgentEvent;
+
+public sealed record MaxIterationsReached(int Iterations) : AgentEvent;

--- a/src/Agent.Core/Orchestrator/AgentOrchestrator.cs
+++ b/src/Agent.Core/Orchestrator/AgentOrchestrator.cs
@@ -156,12 +156,6 @@ public class AgentOrchestrator
                 await LogMessageAsync(toolMessage);
 
                 yield return new ToolExecutionCompleted(toolCall.CallId, toolCall.ToolName, result.Result);
-
-                // Yield approval events if they occurred
-                if (result.ApprovalRequested)
-                    yield return new ApprovalRequested(toolCall.CallId, toolCall.ToolName, toolCall.ArgsJson);
-                if (result.ApprovalResolved)
-                    yield return new ApprovalResult(toolCall.CallId, result.Result.Ok || result.ApprovalGranted);
             }
         }
 

--- a/src/Agent.Core/Orchestrator/AgentOrchestrator.cs
+++ b/src/Agent.Core/Orchestrator/AgentOrchestrator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Agent.Core.Approval;
@@ -35,71 +36,70 @@ public class AgentOrchestrator
         _options = options;
     }
 
-    public async Task RunAsync(
+    public async IAsyncEnumerable<AgentEvent> RunStreamAsync(
         string userPrompt,
-        List<ChatMessage>? messages = null,
-        CancellationToken ct = default)
+        List<ChatMessage> messages,
+        [EnumeratorCancellation] CancellationToken ct = default)
     {
-        messages ??= new List<ChatMessage>();
         var userMessage = new UserMessage(userPrompt);
         messages.Add(userMessage);
 
         await _logger.LogAsync(new { type = "user_prompt", content = userPrompt });
         await LogMessageAsync(userMessage);
 
-        var exhausted = true;
         for (int iteration = 0; iteration < _options.MaxIterations; iteration++)
         {
+            yield return new IterationStarted(iteration, _options.MaxIterations);
+
             var request = BuildRequest(messages);
             var pendingToolCalls = new List<ToolCallReady>();
             var textBuffer = new StringBuilder();
-            var formatter = new TextStreamFormatter();
-
             var completedStop = false;
             string? stopReason = null;
             string? errorDetails = null;
+
             await foreach (var evt in _provider.StreamAsync(request, ct))
             {
                 await _logger.LogAsync(new { type = "event", eventType = evt.GetType().Name, data = evt });
 
                 switch (evt)
                 {
-                    case TextDelta delta:
-                        var rendered = formatter.Format(delta.Text);
-                        Console.Write(rendered);
-                        textBuffer.Append(delta.Text);
+                    case TextDelta:
+                        textBuffer.Append(((TextDelta)evt).Text);
+                        yield return evt;
                         break;
 
-                    case ToolCallStarted started:
-                        Console.Write(formatter.Flush());
-                        Console.WriteLine();
-                        Console.ForegroundColor = ConsoleColor.Cyan;
-                        Console.Write($"[tool] {started.ToolName}");
-                        Console.ResetColor();
+                    case ToolCallStarted:
+                        yield return evt;
+                        break;
+
+                    case ToolCallArgsDelta:
+                        yield return evt;
                         break;
 
                     case ToolCallReady ready:
-                        Console.WriteLine($" args={TruncateJson(ready.ArgsJson, 100)}");
                         pendingToolCalls.Add(ready);
+                        yield return evt;
                         break;
 
                     case TraceEvent trace when trace.Kind == "error":
                         errorDetails = trace.Data;
-                        Console.Write(formatter.Flush());
-                        Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine($"[Provider error] {trace.Data}");
-                        Console.ResetColor();
+                        yield return evt;
                         break;
 
                     case ResponseCompleted completed:
-                        Console.Write(formatter.Flush());
-                        Console.WriteLine();
                         stopReason = completed.StopReason;
                         completedStop = IsCompletionStopReason(completed.StopReason);
+                        yield return evt;
+                        break;
+
+                    default:
+                        yield return evt;
                         break;
                 }
             }
 
+            // Build assistant message from accumulated text and tool calls
             AssistantMessage? assistantMessage = null;
             if (textBuffer.Length > 0 || pendingToolCalls.Count > 0)
             {
@@ -117,75 +117,88 @@ public class AgentOrchestrator
                 await LogMessageAsync(assistantMessage);
             }
 
+            yield return new AssistantMessageCompleted(
+                textBuffer.Length > 0 ? textBuffer.ToString() : null,
+                pendingToolCalls.Count);
+
+            // Check termination conditions
             if (pendingToolCalls.Count == 0 && completedStop)
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("[Agent completed]");
-                Console.ResetColor();
-                return;
+                yield return new AgentCompleted(stopReason ?? "end_turn");
+                yield break;
             }
 
             if (pendingToolCalls.Count == 0 && textBuffer.Length == 0 && !completedStop)
             {
                 var reason = stopReason ?? "unknown";
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.WriteLine($"[No response] stop_reason={reason}");
+                var msg = $"No response. stop_reason={reason}";
                 if (!string.IsNullOrWhiteSpace(errorDetails))
-                {
-                    Console.WriteLine($"[Provider error] {errorDetails}");
-                }
-                Console.ResetColor();
-                return;
+                    msg += $". error={errorDetails}";
+                yield return new AgentError(msg);
+                yield break;
             }
 
-            if (pendingToolCalls.Count > 0)
+            if (pendingToolCalls.Count == 0)
             {
-                foreach (var toolCall in pendingToolCalls)
-                {
-                    var result = await ExecuteToolCallAsync(toolCall, ct);
-                    var toolMessage = new ToolResultMessage(toolCall.CallId, toolCall.ToolName, result);
-                    messages.Add(toolMessage);
-                    await LogMessageAsync(toolMessage);
-
-                    PrintToolResult(toolCall.ToolName, result);
-                }
+                // Text-only response, no tool calls, not a completion stop — break loop
+                yield break;
             }
-            else
+
+            // Execute tool calls
+            foreach (var toolCall in pendingToolCalls)
             {
-                exhausted = false;
-                break;
+                yield return new ToolExecutionStarted(toolCall.CallId, toolCall.ToolName, toolCall.ArgsJson);
+
+                var result = await ExecuteToolCallWithEventsAsync(toolCall, ct);
+
+                var toolMessage = new ToolResultMessage(toolCall.CallId, toolCall.ToolName, result.Result);
+                messages.Add(toolMessage);
+                await LogMessageAsync(toolMessage);
+
+                yield return new ToolExecutionCompleted(toolCall.CallId, toolCall.ToolName, result.Result);
+
+                // Yield approval events if they occurred
+                if (result.ApprovalRequested)
+                    yield return new ApprovalRequested(toolCall.CallId, toolCall.ToolName, toolCall.ArgsJson);
+                if (result.ApprovalResolved)
+                    yield return new ApprovalResult(toolCall.CallId, result.Result.Ok || result.ApprovalGranted);
             }
         }
 
-        if (exhausted)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            Console.WriteLine("[Max iterations reached]");
-            Console.ResetColor();
-        }
+        yield return new MaxIterationsReached(_options.MaxIterations);
     }
 
-    private async Task<ToolResult> ExecuteToolCallAsync(ToolCallReady toolCall, CancellationToken ct)
+    private async Task<ToolExecutionResult> ExecuteToolCallWithEventsAsync(
+        ToolCallReady toolCall, CancellationToken ct)
     {
+        var executionResult = new ToolExecutionResult();
+
         var tool = _toolRegistry.GetTool(toolCall.ToolName);
         if (tool == null)
         {
-            return ToolResult.Failure($"Unknown tool: {toolCall.ToolName}");
+            executionResult.Result = ToolResult.Failure($"Unknown tool: {toolCall.ToolName}");
+            return executionResult;
         }
 
         var decision = await _policyEngine.EvaluateAsync(tool, toolCall.ArgsJson);
         if (decision == PolicyDecision.Denied)
         {
-            return ToolResult.Failure("Tool execution denied by policy");
+            executionResult.Result = ToolResult.Failure("Tool execution denied by policy");
+            return executionResult;
         }
 
         if (decision == PolicyDecision.RequiresApproval)
         {
+            executionResult.ApprovalRequested = true;
             var approved = await _approvalService.RequestApprovalAsync(
                 tool.Name, toolCall.ArgsJson, toolCall.CallId, ct);
+            executionResult.ApprovalResolved = true;
+            executionResult.ApprovalGranted = approved;
+
             if (!approved)
             {
-                return ToolResult.Failure("User denied approval");
+                executionResult.Result = ToolResult.Failure("User denied approval");
+                return executionResult;
             }
         }
 
@@ -199,21 +212,22 @@ public class AgentOrchestrator
                 ApprovalService = _approvalService
             };
 
-            var result = await tool.ExecuteAsync(args, context, ct);
+            executionResult.Result = await tool.ExecuteAsync(args, context, ct);
             await _logger.LogAsync(new
             {
                 type = "tool_result",
                 callId = toolCall.CallId,
                 tool = toolCall.ToolName,
-                ok = result.Ok,
-                diagnostics = result.Diagnostics
+                ok = executionResult.Result.Ok,
+                diagnostics = executionResult.Result.Diagnostics
             });
 
-            return result;
+            return executionResult;
         }
         catch (Exception ex)
         {
-            return ToolResult.Failure($"Tool execution failed: {ex.Message}");
+            executionResult.Result = ToolResult.Failure($"Tool execution failed: {ex.Message}");
+            return executionResult;
         }
     }
 
@@ -228,42 +242,6 @@ public class AgentOrchestrator
             MaxTokens = _options.MaxTokens,
             Temperature = _options.Temperature
         };
-    }
-
-    private static void PrintToolResult(string toolName, ToolResult result)
-    {
-        if (result.Ok)
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine($"  [{toolName}] OK");
-        }
-        else
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine($"  [{toolName}] FAILED: {result.Diagnostics?.FirstOrDefault()?.Message}");
-        }
-        Console.ResetColor();
-
-        if (!string.IsNullOrEmpty(result.Stdout))
-        {
-            var preview = TruncateString(result.Stdout, 200);
-            Console.ForegroundColor = ConsoleColor.DarkGray;
-            Console.WriteLine($"  stdout: {preview}");
-            Console.ResetColor();
-        }
-    }
-
-    private static string TruncateJson(string json, int maxLength)
-    {
-        if (json.Length <= maxLength) return json;
-        return json[..maxLength] + "...";
-    }
-
-    private static string TruncateString(string str, int maxLength)
-    {
-        var singleLine = str.Replace("\r", "").Replace("\n", " ");
-        if (singleLine.Length <= maxLength) return singleLine;
-        return singleLine[..maxLength] + "...";
     }
 
     private static bool IsCompletionStopReason(string? stopReason)
@@ -305,98 +283,11 @@ public class AgentOrchestrator
         };
     }
 
-    private sealed class TextStreamFormatter
+    private sealed class ToolExecutionResult
     {
-        private bool _inCodeBlock;
-        private int _backtickRun;
-        private bool _pendingBackslash;
-
-        public string Format(string text)
-        {
-            if (string.IsNullOrEmpty(text))
-            {
-                return string.Empty;
-            }
-
-            var output = new StringBuilder(text.Length);
-
-            foreach (var ch in text)
-            {
-                if (_pendingBackslash)
-                {
-                    if (ch == 'n' && !_inCodeBlock)
-                    {
-                        output.AppendLine();
-                    }
-                    else
-                    {
-                        output.Append('\\');
-                        ProcessChar(ch, output);
-                    }
-
-                    _pendingBackslash = false;
-                    continue;
-                }
-
-                if (ch == '\\')
-                {
-                    _pendingBackslash = true;
-                    continue;
-                }
-
-                ProcessChar(ch, output);
-            }
-
-            return output.ToString();
-        }
-
-        public string Flush()
-        {
-            var output = new StringBuilder();
-
-            if (_pendingBackslash)
-            {
-                output.Append('\\');
-                _pendingBackslash = false;
-            }
-
-            FlushBackticks(output);
-            return output.ToString();
-        }
-
-        private void ProcessChar(char ch, StringBuilder output)
-        {
-            if (ch == '`')
-            {
-                _backtickRun++;
-                return;
-            }
-
-            FlushBackticks(output);
-            output.Append(ch);
-        }
-
-        private void FlushBackticks(StringBuilder output)
-        {
-            if (_backtickRun == 0)
-            {
-                return;
-            }
-
-            var remaining = _backtickRun;
-            while (remaining >= 3)
-            {
-                _inCodeBlock = !_inCodeBlock;
-                output.Append("```");
-                remaining -= 3;
-            }
-
-            if (remaining > 0)
-            {
-                output.Append('`', remaining);
-            }
-
-            _backtickRun = 0;
-        }
+        public ToolResult Result { get; set; } = ToolResult.Failure("Not executed");
+        public bool ApprovalRequested { get; set; }
+        public bool ApprovalResolved { get; set; }
+        public bool ApprovalGranted { get; set; }
     }
 }

--- a/src/Agent.Core/Tools/ToolRegistry.cs
+++ b/src/Agent.Core/Tools/ToolRegistry.cs
@@ -22,4 +22,16 @@ public class ToolRegistry
     {
         return _tools.Values.Select(t => new ToolDefinition(t.Name, t.Description, t.InputSchema)).ToList();
     }
+
+    public string GetToolDescriptionsMarkdown()
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var tool in _tools.Values)
+        {
+            var readOnly = tool.Policy.IsReadOnly ? " (read-only)" : "";
+            var approval = tool.Policy.RequiresApproval ? " [requires approval]" : "";
+            sb.AppendLine($"- **{tool.Name}**: {tool.Description}{readOnly}{approval}");
+        }
+        return sb.ToString();
+    }
 }

--- a/src/Agent.Server/Services/SessionRunner.cs
+++ b/src/Agent.Server/Services/SessionRunner.cs
@@ -43,7 +43,8 @@ public sealed class SessionRunner
         CoreEvents.TextDelta d => new TextDeltaEvent(d.Text),
         CoreEvents.ToolCallReady r => new ToolCallEvent(r.CallId, r.ToolName, r.ArgsJson),
         CoreEvents.ToolExecutionCompleted c => new Models.ToolResultEvent(c.CallId, c.ToolName, c.Result),
-        CoreEvents.ApprovalRequested a => new ApprovalRequiredEvent(a.CallId, a.ToolName, a.ArgsJson, "RequiresApproval"),
+        // ApprovalRequested is not mapped here — ServerApprovalService already writes
+        // ApprovalRequiredEvent directly to the channel when approval is requested internally.
         CoreEvents.TraceEvent t when t.Kind == "error" => new Models.TraceEvent(t.Kind, t.Data),
         CoreEvents.AgentCompleted c => new CompletedEvent(c.Reason),
         CoreEvents.AgentError e => new ErrorEvent(e.Message),

--- a/src/Agent.Server/Services/SessionRunner.cs
+++ b/src/Agent.Server/Services/SessionRunner.cs
@@ -1,9 +1,5 @@
-using System.Text;
-using System.Text.Json;
-using Agent.Core.Messages;
-using Agent.Core.Policy;
-using Agent.Core.Providers;
-using Agent.Core.Tools;
+using Agent.Core.Events;
+using Agent.Core.Orchestrator;
 using Agent.Server.Models;
 using CoreEvents = Agent.Core.Events;
 
@@ -16,7 +12,25 @@ public sealed class SessionRunner
         await session.RunLock.WaitAsync(ct);
         try
         {
-            await RunInternalAsync(session, userPrompt, ct);
+            var orchestrator = new AgentOrchestrator(
+                session.Provider,
+                session.ToolRegistry,
+                session.ApprovalService,
+                session.PolicyEngine,
+                session.Logger,
+                session.Options);
+
+            var events = session.Events.Writer;
+            session.ApprovalService.AttachChannel(events);
+
+            await foreach (var evt in orchestrator.RunStreamAsync(userPrompt, session.Messages, ct))
+            {
+                var serverEvent = MapToServerEvent(evt);
+                if (serverEvent != null)
+                {
+                    events.TryWrite(serverEvent);
+                }
+            }
         }
         finally
         {
@@ -24,208 +38,16 @@ public sealed class SessionRunner
         }
     }
 
-    private async Task RunInternalAsync(SessionRuntime session, string userPrompt, CancellationToken ct)
+    private static ServerEvent? MapToServerEvent(AgentEvent evt) => evt switch
     {
-        var events = session.Events.Writer;
-        session.ApprovalService.AttachChannel(events);
-
-        var userMessage = new UserMessage(userPrompt);
-        session.Messages.Add(userMessage);
-        await session.Logger.LogAsync(new { type = "user_prompt", content = userPrompt });
-        await LogMessageAsync(session, userMessage);
-
-        var exhausted = true;
-        for (int iteration = 0; iteration < session.Options.MaxIterations; iteration++)
-        {
-            var request = new ModelRequest
-            {
-                Model = session.Options.Model,
-                SystemPrompt = session.Options.SystemPrompt,
-                Messages = session.Messages,
-                Tools = session.ToolRegistry.GetToolDefinitions(),
-                MaxTokens = session.Options.MaxTokens,
-                Temperature = session.Options.Temperature
-            };
-
-            var pendingToolCalls = new List<CoreEvents.ToolCallReady>();
-            var textBuffer = new StringBuilder();
-            var completedStop = false;
-            string? stopReason = null;
-            string? errorDetails = null;
-
-            await foreach (var evt in session.Provider.StreamAsync(request, ct))
-            {
-                await session.Logger.LogAsync(new { type = "event", eventType = evt.GetType().Name, data = evt });
-
-                switch (evt)
-                {
-                    case CoreEvents.TextDelta delta:
-                        textBuffer.Append(delta.Text);
-                        events.TryWrite(new TextDeltaEvent(delta.Text));
-                        break;
-
-                    case CoreEvents.ToolCallReady ready:
-                        pendingToolCalls.Add(ready);
-                        events.TryWrite(new ToolCallEvent(ready.CallId, ready.ToolName, ready.ArgsJson));
-                        break;
-
-                    case CoreEvents.TraceEvent trace when trace.Kind == "error":
-                        errorDetails = trace.Data;
-                        events.TryWrite(new Agent.Server.Models.TraceEvent(trace.Kind, trace.Data));
-                        break;
-
-                    case CoreEvents.ResponseCompleted completed:
-                        stopReason = completed.StopReason;
-                        completedStop = IsCompletionStopReason(completed.StopReason);
-                        events.TryWrite(new CompletedEvent(completed.StopReason));
-                        break;
-                }
-            }
-
-            AssistantMessage? assistantMessage = null;
-            if (textBuffer.Length > 0 || pendingToolCalls.Count > 0)
-            {
-                assistantMessage = new AssistantMessage
-                {
-                    Content = textBuffer.Length > 0 ? textBuffer.ToString() : null,
-                    ToolCalls = pendingToolCalls.Count > 0
-                        ? pendingToolCalls.Select(tc => new ToolCall(tc.CallId, tc.ToolName, tc.ArgsJson)).ToList()
-                        : null
-                };
-                session.Messages.Add(assistantMessage);
-            }
-            if (assistantMessage != null)
-            {
-                await LogMessageAsync(session, assistantMessage);
-            }
-
-            if (pendingToolCalls.Count == 0 && completedStop)
-            {
-                return;
-            }
-
-            if (pendingToolCalls.Count == 0 && textBuffer.Length == 0 && !completedStop)
-            {
-                var reason = stopReason ?? "unknown";
-                events.TryWrite(new ErrorEvent($"No response. stop_reason={reason}. error={errorDetails}"));
-                return;
-            }
-
-            if (pendingToolCalls.Count > 0)
-            {
-                foreach (var toolCall in pendingToolCalls)
-                {
-                    var result = await ExecuteToolCallAsync(session, toolCall, ct);
-                    var toolMessage = new ToolResultMessage(toolCall.CallId, toolCall.ToolName, result);
-                    session.Messages.Add(toolMessage);
-                    await LogMessageAsync(session, toolMessage);
-                    events.TryWrite(new Agent.Server.Models.ToolResultEvent(toolCall.CallId, toolCall.ToolName, result));
-                }
-            }
-            else
-            {
-                exhausted = false;
-                break;
-            }
-        }
-
-        if (exhausted)
-        {
-            events.TryWrite(new ErrorEvent("Max iterations reached."));
-        }
-    }
-
-    private async Task<ToolResult> ExecuteToolCallAsync(
-        SessionRuntime session,
-        CoreEvents.ToolCallReady toolCall,
-        CancellationToken ct)
-    {
-        var tool = session.ToolRegistry.GetTool(toolCall.ToolName);
-        if (tool == null)
-        {
-            return ToolResult.Failure($"Unknown tool: {toolCall.ToolName}");
-        }
-
-        var decision = await session.PolicyEngine.EvaluateAsync(tool, toolCall.ArgsJson);
-        if (decision == PolicyDecision.Denied)
-        {
-            return ToolResult.Failure("Tool execution denied by policy");
-        }
-
-        if (decision == PolicyDecision.RequiresApproval)
-        {
-            var approved = await session.ApprovalService.RequestApprovalAsync(
-                tool.Name, toolCall.ArgsJson, toolCall.CallId, ct);
-            if (!approved)
-            {
-                return ToolResult.Failure("User denied approval");
-            }
-        }
-
-        try
-        {
-            var args = JsonDocument.Parse(toolCall.ArgsJson).RootElement;
-            var context = new ToolContext
-            {
-                RepoRoot = session.Options.RepoRoot,
-                Workspace = session.Options.Workspace,
-                ApprovalService = session.ApprovalService
-            };
-
-            var result = await tool.ExecuteAsync(args, context, ct);
-            await session.Logger.LogAsync(new
-            {
-                type = "tool_result",
-                callId = toolCall.CallId,
-                tool = toolCall.ToolName,
-                ok = result.Ok,
-                diagnostics = result.Diagnostics
-            });
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            return ToolResult.Failure($"Tool execution failed: {ex.Message}");
-        }
-    }
-
-    private static bool IsCompletionStopReason(string? stopReason)
-    {
-        return stopReason == "end_turn" || stopReason == "stop";
-    }
-
-    private static Task LogMessageAsync(SessionRuntime session, ChatMessage message)
-    {
-        return message switch
-        {
-            UserMessage userMessage => session.Logger.LogAsync(new
-            {
-                type = "message",
-                role = userMessage.Role,
-                content = userMessage.Content
-            }),
-            AssistantMessage assistantMessage => session.Logger.LogAsync(new
-            {
-                type = "message",
-                role = assistantMessage.Role,
-                content = assistantMessage.Content,
-                toolCalls = assistantMessage.ToolCalls?.Select(tc => new
-                {
-                    callId = tc.CallId,
-                    name = tc.Name,
-                    argsJson = tc.ArgsJson
-                })
-            }),
-            ToolResultMessage toolResultMessage => session.Logger.LogAsync(new
-            {
-                type = "message",
-                role = toolResultMessage.Role,
-                callId = toolResultMessage.CallId,
-                toolName = toolResultMessage.ToolName,
-                result = toolResultMessage.Result
-            }),
-            _ => session.Logger.LogAsync(new { type = "message", role = message.Role })
-        };
-    }
+        CoreEvents.TextDelta d => new TextDeltaEvent(d.Text),
+        CoreEvents.ToolCallReady r => new ToolCallEvent(r.CallId, r.ToolName, r.ArgsJson),
+        CoreEvents.ToolExecutionCompleted c => new Models.ToolResultEvent(c.CallId, c.ToolName, c.Result),
+        CoreEvents.ApprovalRequested a => new ApprovalRequiredEvent(a.CallId, a.ToolName, a.ArgsJson, "RequiresApproval"),
+        CoreEvents.TraceEvent t when t.Kind == "error" => new Models.TraceEvent(t.Kind, t.Data),
+        CoreEvents.AgentCompleted c => new CompletedEvent(c.Reason),
+        CoreEvents.AgentError e => new ErrorEvent(e.Message),
+        CoreEvents.MaxIterationsReached _ => new ErrorEvent("Max iterations reached."),
+        _ => null
+    };
 }

--- a/src/Agent.Server/Services/SessionRuntimeFactory.cs
+++ b/src/Agent.Server/Services/SessionRuntimeFactory.cs
@@ -86,7 +86,7 @@ public sealed class SessionRuntimeFactory
             Workspace = workspace,
             MaxIterations = 20,
             MaxTokens = 4096,
-            SystemPrompt = SystemPromptProvider.GetSystemPrompt()
+            SystemPrompt = SystemPromptProvider.GetSystemPrompt(toolRegistry, repoRoot)
         };
 
         var runtime = new SessionRuntime(
@@ -202,6 +202,7 @@ public sealed class SessionRuntimeFactory
         registry.Register(new SearchTextTool());
         registry.Register(new GitStatusTool());
         registry.Register(new GitDiffTool());
+        registry.Register(new FileEditTool());
         registry.Register(new ApplyPatchTool());
         registry.Register(new RunCommandTool());
 

--- a/src/Agent.Server/Services/SystemPromptProvider.cs
+++ b/src/Agent.Server/Services/SystemPromptProvider.cs
@@ -1,39 +1,37 @@
+using Agent.Core.Tools;
+
 namespace Agent.Server.Services;
 
 public static class SystemPromptProvider
 {
-    public static string GetSystemPrompt()
+    public static string GetSystemPrompt(ToolRegistry toolRegistry, string repoRoot)
     {
-        return """
+        var toolDescriptions = toolRegistry.GetToolDescriptionsMarkdown();
+
+        var projectPromptPath = Path.Combine(repoRoot, ".asdv", "prompt.md");
+        var projectPrompt = File.Exists(projectPromptPath)
+            ? Environment.NewLine + File.ReadAllText(projectPromptPath)
+            : "";
+
+        return $"""
             You are a coding assistant that helps developers with tasks in their local repository.
 
             ## Available Tools
 
-            ### Reading & Exploration
-            - **ReadFile**: Read file contents (supports line ranges)
-            - **ListFiles**: List files matching glob patterns (e.g., **/*.cs)
-            - **SearchText**: Search for text patterns using regex
-
-            ### Git Operations
-            - **GitStatus**: Get current repository status
-            - **GitDiff**: View changes (staged or unstaged)
-
-            ### Modifications
-            - **ApplyPatch**: Apply unified diff patches to modify files
-            - **RunCommand**: Execute shell commands (requires approval)
-
+            {toolDescriptions}
             ## Guidelines
 
             1. **Understand First**: Always read relevant files before making changes
             2. **Search Effectively**: Use SearchText to locate code patterns
-            3. **Precise Changes**: Generate minimal, focused unified diff patches
+            3. **Precise Edits**: Use FileEdit for targeted string replacements, or ApplyPatch for larger changes
             4. **Verify Results**: Check git status/diff after modifications
             5. **Test Changes**: Run tests when appropriate
             6. **Explain Actions**: Briefly describe what you're doing and why
 
-            ## Patch Format
+            ## Edit Strategies
 
-            When modifying files, prefer unified diff format:
+            For small, targeted changes, prefer FileEdit (exact string replacement).
+            For larger or multi-site changes, use ApplyPatch with unified diff format:
             ```
             --- a/path/to/file.cs
             +++ b/path/to/file.cs
@@ -44,15 +42,8 @@ public static class SystemPromptProvider
              context line
             ```
 
-            The ApplyPatch tool also accepts the "Begin Patch" format:
-            ```
-            *** Begin Patch
-            *** Add File: path/to/file.cs
-            +new line
-            *** End Patch
-            ```
-
-            Keep patches minimal and focused on the specific change needed.
+            Keep changes minimal and focused on the specific task.
+            {projectPrompt}
             """;
     }
 }

--- a/src/Agent.Tools/FileEditTool.cs
+++ b/src/Agent.Tools/FileEditTool.cs
@@ -40,6 +40,11 @@ public class FileEditTool : ITool
             return ToolResult.Failure($"File not found: {filePath}");
         }
 
+        if (string.IsNullOrEmpty(oldString))
+        {
+            return ToolResult.Failure("old_string must not be empty.");
+        }
+
         var content = await File.ReadAllTextAsync(fullPath, ct);
 
         var count = CountOccurrences(content, oldString);

--- a/src/Agent.Tools/FileEditTool.cs
+++ b/src/Agent.Tools/FileEditTool.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Agent.Core.Tools;
+
+namespace Agent.Tools;
+
+public class FileEditTool : ITool
+{
+    public string Name => "FileEdit";
+    public string Description => "Replace exact text in a file. The old_string must appear exactly once unless replace_all is true.";
+    public ToolPolicy Policy => new() { RequiresApproval = true, Risk = RiskLevel.Medium };
+
+    public string InputSchema => """
+    {
+        "type": "object",
+        "properties": {
+            "filePath": { "type": "string", "description": "Relative path to the file to edit" },
+            "oldString": { "type": "string", "description": "The exact text to find and replace" },
+            "newString": { "type": "string", "description": "The replacement text" },
+            "replaceAll": { "type": "boolean", "description": "Replace all occurrences (default: false)" }
+        },
+        "required": ["filePath", "oldString", "newString"]
+    }
+    """;
+
+    public async Task<ToolResult> ExecuteAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
+    {
+        var filePath = args.GetProperty("filePath").GetString()!;
+        var oldString = args.GetProperty("oldString").GetString()!;
+        var newString = args.GetProperty("newString").GetString()!;
+        var replaceAll = args.TryGetProperty("replaceAll", out var ra) && ra.GetBoolean();
+
+        var fullPath = ctx.Workspace.ResolvePath(filePath);
+        if (fullPath == null)
+        {
+            return ToolResult.Failure($"Path traversal detected or path outside repo: {filePath}");
+        }
+
+        if (!File.Exists(fullPath))
+        {
+            return ToolResult.Failure($"File not found: {filePath}");
+        }
+
+        var content = await File.ReadAllTextAsync(fullPath, ct);
+
+        var count = CountOccurrences(content, oldString);
+        if (count == 0)
+        {
+            return ToolResult.Failure("old_string not found in file.");
+        }
+
+        if (count > 1 && !replaceAll)
+        {
+            return ToolResult.Failure(
+                $"old_string found {count} times. Set replaceAll=true to replace all, or provide more context to make it unique.");
+        }
+
+        if (oldString == newString)
+        {
+            return ToolResult.Failure("old_string and new_string are identical. No change needed.");
+        }
+
+        var newContent = replaceAll
+            ? content.Replace(oldString, newString)
+            : ReplaceFirst(content, oldString, newString);
+
+        await File.WriteAllTextAsync(fullPath, newContent, ct);
+
+        var replacedCount = replaceAll ? count : 1;
+
+        return ToolResult.Success(new
+        {
+            filePath,
+            replacements = replacedCount,
+            message = $"Replaced {replacedCount} occurrence(s) in {filePath}"
+        });
+    }
+
+    private static int CountOccurrences(string text, string search)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(search, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += search.Length;
+        }
+        return count;
+    }
+
+    private static string ReplaceFirst(string text, string oldValue, string newValue)
+    {
+        var index = text.IndexOf(oldValue, StringComparison.Ordinal);
+        if (index < 0) return text;
+        return string.Concat(text.AsSpan(0, index), newValue, text.AsSpan(index + oldValue.Length));
+    }
+}

--- a/src/Agent.Tools/ListFilesTool.cs
+++ b/src/Agent.Tools/ListFilesTool.cs
@@ -55,12 +55,14 @@ public class ListFilesTool : ITool
 
         var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(searchRoot)));
 
-        IEnumerable<string> filePaths = result.Files.Select(f => f.Path.Replace('\\', '/'));
+        // Prefix subPath to make paths repo-root-relative (Matcher returns paths relative to searchRoot)
+        var prefix = !string.IsNullOrWhiteSpace(subPath) ? subPath.TrimEnd('/').Replace('\\', '/') + "/" : "";
+        IEnumerable<string> filePaths = result.Files.Select(f => prefix + f.Path.Replace('\\', '/'));
 
         if (sortBy == "modified")
         {
             filePaths = filePaths
-                .Select(f => (path: f, mtime: File.GetLastWriteTimeUtc(Path.Combine(searchRoot, f))))
+                .Select(f => (path: f, mtime: File.GetLastWriteTimeUtc(Path.Combine(ctx.RepoRoot, f))))
                 .OrderByDescending(x => x.mtime)
                 .Select(x => x.path);
         }

--- a/src/Agent.Tools/ListFilesTool.cs
+++ b/src/Agent.Tools/ListFilesTool.cs
@@ -16,7 +16,8 @@ public class ListFilesTool : ITool
         "type": "object",
         "properties": {
             "glob": { "type": "string", "description": "Glob pattern (e.g., **/*.cs)" },
-            "maxDepth": { "type": "integer", "default": 10 }
+            "path": { "type": "string", "description": "Subdirectory to search in (relative, default: repo root)" },
+            "sortBy": { "type": "string", "enum": ["name", "modified"], "description": "Sort order (default: name)" }
         },
         "required": ["glob"]
     }
@@ -25,6 +26,23 @@ public class ListFilesTool : ITool
     public Task<ToolResult> ExecuteAsync(JsonElement args, ToolContext ctx, CancellationToken ct)
     {
         var glob = args.GetProperty("glob").GetString()!;
+        var subPath = args.TryGetProperty("path", out var p) ? p.GetString() : null;
+        var sortBy = args.TryGetProperty("sortBy", out var s) ? s.GetString() : "name";
+
+        var searchRoot = ctx.RepoRoot;
+        if (!string.IsNullOrWhiteSpace(subPath))
+        {
+            var resolved = ctx.Workspace.ResolvePath(subPath);
+            if (resolved == null)
+            {
+                return Task.FromResult(ToolResult.Failure($"Path outside repo: {subPath}"));
+            }
+            if (!Directory.Exists(resolved))
+            {
+                return Task.FromResult(ToolResult.Failure($"Directory not found: {subPath}"));
+            }
+            searchRoot = resolved;
+        }
 
         var matcher = new Matcher();
         matcher.AddInclude(glob);
@@ -35,16 +53,24 @@ public class ListFilesTool : ITool
         matcher.AddExclude("**/bin/**");
         matcher.AddExclude("**/obj/**");
 
-        var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(ctx.RepoRoot)));
+        var result = matcher.Execute(new DirectoryInfoWrapper(new DirectoryInfo(searchRoot)));
 
-        var files = result.Files
-            .Select(f => f.Path.Replace('\\', '/'))
-            .Take(500)
-            .ToList();
+        IEnumerable<string> filePaths = result.Files.Select(f => f.Path.Replace('\\', '/'));
+
+        if (sortBy == "modified")
+        {
+            filePaths = filePaths
+                .Select(f => (path: f, mtime: File.GetLastWriteTimeUtc(Path.Combine(searchRoot, f))))
+                .OrderByDescending(x => x.mtime)
+                .Select(x => x.path);
+        }
+
+        var files = filePaths.Take(500).ToList();
 
         return Task.FromResult(ToolResult.Success(new
         {
             pattern = glob,
+            searchRoot = searchRoot == ctx.RepoRoot ? "." : subPath,
             count = files.Count,
             files
         }));

--- a/src/Agent.Tools/SearchTextTool.cs
+++ b/src/Agent.Tools/SearchTextTool.cs
@@ -18,7 +18,9 @@ public class SearchTextTool : ITool
             "query": { "type": "string", "description": "Search pattern (regex supported)" },
             "includeGlobs": { "type": "array", "items": { "type": "string" }, "description": "Glob patterns to include" },
             "excludeGlobs": { "type": "array", "items": { "type": "string" }, "description": "Glob patterns to exclude" },
-            "maxResults": { "type": "integer", "default": 50 }
+            "maxResults": { "type": "integer", "default": 50 },
+            "contextLines": { "type": "integer", "description": "Number of context lines before and after each match (default: 0)" },
+            "caseSensitive": { "type": "boolean", "description": "Case-sensitive search (default: false)" }
         },
         "required": ["query"]
     }
@@ -31,16 +33,18 @@ public class SearchTextTool : ITool
     {
         var query = args.GetProperty("query").GetString()!;
         var maxResults = args.TryGetProperty("maxResults", out var m) ? m.GetInt32() : 50;
+        var contextLines = args.TryGetProperty("contextLines", out var cl) ? cl.GetInt32() : 0;
+        var caseSensitive = args.TryGetProperty("caseSensitive", out var cs) && cs.GetBoolean();
 
         // Try ripgrep first if available
         var rgPath = FindRipgrep();
         if (rgPath != null)
         {
-            return await SearchWithRipgrepAsync(rgPath, query, ctx.RepoRoot, maxResults, ct);
+            return await SearchWithRipgrepAsync(rgPath, query, ctx.RepoRoot, maxResults, contextLines, caseSensitive, ct);
         }
 
         // Fallback to manual search
-        return await SearchManuallyAsync(query, ctx.RepoRoot, maxResults, ct);
+        return await SearchManuallyAsync(query, ctx.RepoRoot, maxResults, contextLines, caseSensitive, ct);
     }
 
     private static string? FindRipgrep()
@@ -65,7 +69,8 @@ public class SearchTextTool : ITool
     }
 
     private async Task<ToolResult> SearchWithRipgrepAsync(
-        string rgPath, string query, string root, int maxResults, CancellationToken ct)
+        string rgPath, string query, string root, int maxResults,
+        int contextLines, bool caseSensitive, CancellationToken ct)
     {
         var psi = new ProcessStartInfo
         {
@@ -80,6 +85,15 @@ public class SearchTextTool : ITool
         psi.ArgumentList.Add("--json");
         psi.ArgumentList.Add("-m");
         psi.ArgumentList.Add(maxResults.ToString());
+        if (contextLines > 0)
+        {
+            psi.ArgumentList.Add("-C");
+            psi.ArgumentList.Add(contextLines.ToString());
+        }
+        if (!caseSensitive)
+        {
+            psi.ArgumentList.Add("-i");
+        }
         psi.ArgumentList.Add("--");
         psi.ArgumentList.Add(query);
 
@@ -139,12 +153,16 @@ public class SearchTextTool : ITool
     }
 
     private async Task<ToolResult> SearchManuallyAsync(
-        string query, string root, int maxResults, CancellationToken ct)
+        string query, string root, int maxResults, int contextLines, bool caseSensitive,
+        CancellationToken ct)
     {
         Regex regex;
         try
         {
-            regex = new Regex(query, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            var regexOptions = RegexOptions.Compiled;
+            if (!caseSensitive)
+                regexOptions |= RegexOptions.IgnoreCase;
+            regex = new Regex(query, regexOptions);
         }
         catch (ArgumentException ex)
         {
@@ -160,16 +178,36 @@ public class SearchTextTool : ITool
             try
             {
                 var lines = await File.ReadAllLinesAsync(file, ct);
+                var relPath = Path.GetRelativePath(root, file).Replace('\\', '/');
                 for (int i = 0; i < lines.Length && results.Count < maxResults; i++)
                 {
                     if (regex.IsMatch(lines[i]))
                     {
-                        results.Add(new
+                        if (contextLines > 0)
                         {
-                            file = Path.GetRelativePath(root, file).Replace('\\', '/'),
-                            line = i + 1,
-                            content = lines[i].Trim()
-                        });
+                            var ctxStart = Math.Max(0, i - contextLines);
+                            var ctxEnd = Math.Min(lines.Length - 1, i + contextLines);
+                            var context = string.Join("\n",
+                                Enumerable.Range(ctxStart, ctxEnd - ctxStart + 1)
+                                    .Select(j => $"{j + 1}: {lines[j]}"));
+                            results.Add(new
+                            {
+                                file = relPath,
+                                line = i + 1,
+                                content = lines[i].Trim(),
+                                context
+                            });
+                        }
+                        else
+                        {
+                            results.Add(new
+                            {
+                                file = relPath,
+                                line = i + 1,
+                                content = lines[i].Trim(),
+                                context = (string?)null
+                            });
+                        }
                     }
                 }
             }

--- a/tests/Agent.Core.Tests/AutoApprovalServiceTests.cs
+++ b/tests/Agent.Core.Tests/AutoApprovalServiceTests.cs
@@ -1,0 +1,28 @@
+using Agent.Core.Approval;
+using FluentAssertions;
+
+namespace Agent.Core.Tests;
+
+public class AutoApprovalServiceTests
+{
+    [Fact]
+    public async Task RequestApprovalAsync_AlwaysReturnsTrue()
+    {
+        var service = new AutoApprovalService();
+
+        var result = await service.RequestApprovalAsync("RunCommand", "{}", "call1");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_WithCancellation_StillReturnsTrue()
+    {
+        var service = new AutoApprovalService();
+        using var cts = new CancellationTokenSource();
+
+        var result = await service.RequestApprovalAsync("ApplyPatch", "{}", null, cts.Token);
+
+        result.Should().BeTrue();
+    }
+}

--- a/tests/Agent.Server.Tests/Agent.Server.Tests.csproj
+++ b/tests/Agent.Server.Tests/Agent.Server.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Agent.Cli\Agent.Cli.csproj" />
     <ProjectReference Include="..\..\src\Agent.Server\Agent.Server.csproj" />
   </ItemGroup>
 

--- a/tests/Agent.Server.Tests/SessionLogReaderResumeModeTests.cs
+++ b/tests/Agent.Server.Tests/SessionLogReaderResumeModeTests.cs
@@ -1,0 +1,102 @@
+using Agent.Cli;
+using Agent.Core.Messages;
+using FluentAssertions;
+
+namespace Agent.Server.Tests;
+
+public class SessionLogReaderResumeModeTests
+{
+    private string CreateSessionLog(params string[] lines)
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllLines(path, lines);
+        return path;
+    }
+
+    private static string UserLine(string content) =>
+        $"{{\"timestamp\":\"2024-01-01T00:00:00Z\",\"data\":{{\"type\":\"message\",\"role\":\"user\",\"content\":\"{content}\"}}}}";
+
+    private static string AssistantLine(string content) =>
+        $"{{\"timestamp\":\"2024-01-01T00:00:01Z\",\"data\":{{\"type\":\"message\",\"role\":\"assistant\",\"content\":\"{content}\"}}}}";
+
+    private static string ToolLine(string callId, string toolName) =>
+        $"{{\"timestamp\":\"2024-01-01T00:00:02Z\",\"data\":{{\"type\":\"message\",\"role\":\"tool\",\"callId\":\"{callId}\",\"toolName\":\"{toolName}\",\"result\":{{\"ok\":true}}}}}}";
+
+    [Fact]
+    public void LoadMessages_FullMode_ReturnsAllMessages()
+    {
+        var path = CreateSessionLog(UserLine("first"), AssistantLine("reply1"), UserLine("second"), AssistantLine("reply2"));
+        try
+        {
+            var messages = SessionLogReader.LoadMessages(path, ResumeMode.Full, 0);
+            messages.Should().HaveCount(4);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void LoadMessages_LastN_ReturnsLastNTurns()
+    {
+        var path = CreateSessionLog(
+            UserLine("turn1"), AssistantLine("reply1"),
+            UserLine("turn2"), AssistantLine("reply2"),
+            UserLine("turn3"), AssistantLine("reply3"));
+        try
+        {
+            var messages = SessionLogReader.LoadMessages(path, ResumeMode.LastN, 2);
+
+            messages.Should().HaveCount(4); // last 2 turns = 4 messages
+            messages[0].Should().BeOfType<UserMessage>();
+            ((UserMessage)messages[0]).Content.Should().Be("turn2");
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void LoadMessages_LastN_LargerThanTotal_ReturnsAll()
+    {
+        var path = CreateSessionLog(UserLine("only"), AssistantLine("reply"));
+        try
+        {
+            var messages = SessionLogReader.LoadMessages(path, ResumeMode.LastN, 10);
+            messages.Should().HaveCount(2);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void LoadMessages_Summary_ReturnsSingleMessage()
+    {
+        var path = CreateSessionLog(
+            UserLine("do something"),
+            AssistantLine("ok"),
+            ToolLine("c1", "ReadFile"),
+            UserLine("now fix it"),
+            AssistantLine("done"));
+        try
+        {
+            var messages = SessionLogReader.LoadMessages(path, ResumeMode.Summary, 0);
+
+            messages.Should().HaveCount(1);
+            messages[0].Should().BeOfType<UserMessage>();
+            var summary = ((UserMessage)messages[0]).Content;
+            summary.Should().Contain("2 user messages");
+            summary.Should().Contain("ReadFile");
+            summary.Should().Contain("now fix it"); // last user prompt
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void LoadMessages_Summary_EmptySession_ReturnsEmpty()
+    {
+        var path = Path.GetTempFileName();
+        File.WriteAllText(path, "");
+        try
+        {
+            var messages = SessionLogReader.LoadMessages(path, ResumeMode.Summary, 0);
+            messages.Should().BeEmpty();
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/Agent.Tools.Tests/FileEditToolTests.cs
+++ b/tests/Agent.Tools.Tests/FileEditToolTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using Agent.Core.Approval;
+using Agent.Core.Tools;
+using Agent.Tools;
+using Agent.Workspace;
+using FluentAssertions;
+using Moq;
+
+namespace Agent.Tools.Tests;
+
+public class FileEditToolTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly LocalWorkspace _workspace;
+    private readonly ToolContext _context;
+    private readonly FileEditTool _tool;
+
+    public FileEditToolTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), "agent_fileedit_test_" + Guid.NewGuid());
+        Directory.CreateDirectory(_testRoot);
+        _workspace = new LocalWorkspace(_testRoot);
+        _context = new ToolContext
+        {
+            RepoRoot = _testRoot,
+            Workspace = _workspace,
+            ApprovalService = Mock.Of<IApprovalService>()
+        };
+        _tool = new FileEditTool();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_testRoot, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UniqueMatch_ReplacesSuccessfully()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "public class Foo { }");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "Foo", "newString": "Bar"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        var content = await File.ReadAllTextAsync(file);
+        content.Should().Be("public class Bar { }");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleMatches_FailsWithoutReplaceAll()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "foo bar foo baz foo");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "foo", "newString": "qux"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("3 times"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MultipleMatches_ReplacesAllWhenFlagged()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "foo bar foo baz foo");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "foo", "newString": "qux", "replaceAll": true}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        var content = await File.ReadAllTextAsync(file);
+        content.Should().Be("qux bar qux baz qux");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OldStringNotFound_Fails()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "hello world");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "notfound", "newString": "x"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_EmptyOldString_Fails()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "hello world");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "", "newString": "x"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("must not be empty"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SameOldAndNew_Fails()
+    {
+        var file = Path.Combine(_testRoot, "test.cs");
+        await File.WriteAllTextAsync(file, "hello world");
+        var args = JsonDocument.Parse("""{"filePath": "test.cs", "oldString": "hello", "newString": "hello"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("identical"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FileNotFound_Fails()
+    {
+        var args = JsonDocument.Parse("""{"filePath": "nonexistent.cs", "oldString": "a", "newString": "b"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PathTraversal_Fails()
+    {
+        var args = JsonDocument.Parse("""{"filePath": "../etc/passwd", "oldString": "a", "newString": "b"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("traversal"));
+    }
+
+    [Fact]
+    public void Tool_HasCorrectMetadata()
+    {
+        _tool.Name.Should().Be("FileEdit");
+        _tool.Policy.RequiresApproval.Should().BeTrue();
+        _tool.Policy.IsReadOnly.Should().BeFalse();
+    }
+}

--- a/tests/Agent.Tools.Tests/ListFilesToolEnhancedTests.cs
+++ b/tests/Agent.Tools.Tests/ListFilesToolEnhancedTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Agent.Core.Approval;
+using Agent.Core.Tools;
+using Agent.Tools;
+using Agent.Workspace;
+using FluentAssertions;
+using Moq;
+
+namespace Agent.Tools.Tests;
+
+public class ListFilesToolEnhancedTests : IDisposable
+{
+    private readonly string _testRoot;
+    private readonly LocalWorkspace _workspace;
+    private readonly ToolContext _context;
+    private readonly ListFilesTool _tool;
+
+    public ListFilesToolEnhancedTests()
+    {
+        _testRoot = Path.Combine(Path.GetTempPath(), "agent_listfiles_enhanced_" + Guid.NewGuid());
+        Directory.CreateDirectory(_testRoot);
+        _workspace = new LocalWorkspace(_testRoot);
+        _context = new ToolContext
+        {
+            RepoRoot = _testRoot,
+            Workspace = _workspace,
+            ApprovalService = Mock.Of<IApprovalService>()
+        };
+        _tool = new ListFilesTool();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_testRoot, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPath_ReturnsRepoRootRelativePaths()
+    {
+        var srcDir = Path.Combine(_testRoot, "src");
+        Directory.CreateDirectory(srcDir);
+        await File.WriteAllTextAsync(Path.Combine(srcDir, "Program.cs"), "content");
+        await File.WriteAllTextAsync(Path.Combine(srcDir, "Util.cs"), "content");
+
+        var args = JsonDocument.Parse("""{"glob": "*.cs", "path": "src"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        var data = JsonSerializer.Serialize(result.Data);
+        // Paths must be repo-root-relative, not searchRoot-relative
+        data.Should().Contain("src/Program.cs");
+        data.Should().Contain("src/Util.cs");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutPath_ReturnsRepoRootRelativePaths()
+    {
+        var srcDir = Path.Combine(_testRoot, "src");
+        Directory.CreateDirectory(srcDir);
+        await File.WriteAllTextAsync(Path.Combine(srcDir, "App.cs"), "content");
+
+        var args = JsonDocument.Parse("""{"glob": "**/*.cs"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        var data = JsonSerializer.Serialize(result.Data);
+        data.Should().Contain("src/App.cs");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidPath_Fails()
+    {
+        var args = JsonDocument.Parse("""{"glob": "*.cs", "path": "nonexistent"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeFalse();
+        result.Diagnostics.Should().Contain(d => d.Message.Contains("not found"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SortByModified_ReturnsMostRecentFirst()
+    {
+        var srcDir = Path.Combine(_testRoot, "src");
+        Directory.CreateDirectory(srcDir);
+
+        var oldFile = Path.Combine(srcDir, "old.cs");
+        await File.WriteAllTextAsync(oldFile, "old");
+        File.SetLastWriteTimeUtc(oldFile, DateTime.UtcNow.AddHours(-2));
+
+        var newFile = Path.Combine(srcDir, "new.cs");
+        await File.WriteAllTextAsync(newFile, "new");
+        File.SetLastWriteTimeUtc(newFile, DateTime.UtcNow);
+
+        var args = JsonDocument.Parse("""{"glob": "**/*.cs", "sortBy": "modified"}""").RootElement;
+
+        var result = await _tool.ExecuteAsync(args, _context, CancellationToken.None);
+
+        result.Ok.Should().BeTrue();
+        var data = JsonSerializer.Serialize(result.Data);
+        var newIdx = data.IndexOf("new.cs", StringComparison.Ordinal);
+        var oldIdx = data.IndexOf("old.cs", StringComparison.Ordinal);
+        newIdx.Should().BeLessThan(oldIdx, "newer file should appear first");
+    }
+}


### PR DESCRIPTION
## Description

- **Unified event-driven orchestrator**: Replaced two near-identical agent loops (CLI's `AgentOrchestrator` and Server's `SessionRunner`) with a single `IAsyncEnumerable<AgentEvent>` generator in Agent.Core. Both CLI and Server now consume the same event stream through thin adapters — eliminating ~200 lines of duplicate logic.
- **New tools and enhancements**: Added `FileEditTool` for precise string replacement. Enhanced `ListFilesTool` with `path` and `sortBy=modified` parameters. Enhanced `SearchTextTool` with `contextLines` and `caseSensitive` parameters.
- **Command system**: Added `/status`, `/help`, `/diff` REPL commands via a new `ICommand`/`CommandRegistry` infrastructure.
- **Resume modes**: Added `--resume-mode=full|summary|last-N` for flexible session resumption — critical for local LLMs with small context windows.
- **Project-level prompts**: System prompt is now auto-generated from the tool registry. Supports `.asdv/prompt.md` for per-project customization.

## Key architectural changes

- `AgentOrchestrator.RunStreamAsync()` yields typed events (`IterationStarted`, `ToolExecutionStarted`, `ApprovalRequested`, `AgentCompleted`, etc.)
- CLI renders via `ConsoleEventRenderer`; Server maps to `ServerEvent` via a simple switch expression
- `SessionRunner.cs`: 232 lines → 56 lines (delegate to unified orchestrator)
- Hybrid approval model: `IApprovalService` stays as injected callback, new `AutoApprovalService` for `--yes` mode

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 53/53 tests pass (21 Core + 9 Server + 23 Tools)
- [ ] Manual CLI smoke test: REPL mode, `/status`, `/help`, `/diff` commands
- [ ] Manual test: `--resume-mode=summary` and `--resume-mode=last-3` with existing session
- [ ] Manual test: `FileEditTool` via agent prompt
- [ ] Manual Server test: SSE streaming still works after SessionRunner migration